### PR TITLE
add reference grant to allow httproute work

### DIFF
--- a/self-managed/README.md
+++ b/self-managed/README.md
@@ -12,7 +12,7 @@
     2. Consul K8S:
     `consul-k8s install -config-file=consul/config.yaml -set global.image=hashicorp/consul:1.13.1`
 8. `kubectl apply --filename two-services`
-9.  `kubectl apply --filename api-gw/consul-api-gateway.yaml --namespace consul && kubectl wait --for=condition=ready gateway/api-gateway --namespace consul --timeout=90s && kubectl apply --filename api-gw/routes.yaml --namespace consul` 
+9.  `kubectl apply --filename api-gw/consul-api-gateway.yaml --namespace consul && kubectl wait --for=condition=ready gateway/api-gateway --namespace consul --timeout=90s && kubectl apply --filename api-gw/routes.yaml --namespace consul && kubectl apply --filename api-gw/referencegrant.yaml`
 10.  `kubectl port-forward svc/consul-ui --namespace consul 6443:443`
 11. Visit the following urls in the browser
     1.  [https://localhost:6443/ui/](https://localhost:6443/ui/)

--- a/self-managed/api-gw/referencegrant.yaml
+++ b/self-managed/api-gw/referencegrant.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: ReferenceGrant
+metadata:
+  name: consul-reference-grant
+  namespace: default
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: consul  # Must match the namespace that api-gw/routes.yaml is deployed into
+  to:
+    - group: ""
+      kind: Service


### PR DESCRIPTION
I was following along with this tutorial https://developer.hashicorp.com/consul/tutorials/developer-mesh/kubernetes-api-gateway. But the API Gateway doesn't workin without deploying referecence grant. Added the required resource definition and depoy command in readme.